### PR TITLE
feat: Add Docker Compose setup and fix build environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,5 +30,5 @@ RUN rm -rf /usr/share/nginx/html/*
 
 ## From ‘builder’ stage copy over the artifacts in dist folder to default nginx public folder
 COPY --from=builder /ng-app/dist /usr/share/nginx/html
-
+EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+services:
+  ovvl-webapp:
+    # Build the service from the Dockerfile in the current directory
+    build:
+      context: .
+      dockerfile: Dockerfile    
+    container_name: ovvl_webapp
+    ports:
+      - "80:80"
+    restart: unless-stopped


### PR DESCRIPTION
fixing the build, adding Docker Compose support

Now, use `docker compose up --build -d` to start the whole OVVL webapp